### PR TITLE
Support per-user history with local SQLite database

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,16 +1,102 @@
-from fastapi import FastAPI
+"""FastAPI application providing chat and user management endpoints."""
+
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
 from backend.services.openrouter import chat_with_openrouter
+from backend.services import models
+from backend.services.database import SessionLocal, engine
+
+
+models.Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 app = FastAPI(title="AI Learning Lab")
 
 
 class ChatRequest(BaseModel):
+    user_id: int
     message: str
 
 
+class UserCreate(BaseModel):
+    name: str
+    preferences: str = ""
+
+
+class PreferencesUpdate(BaseModel):
+    preferences: str
+
+
 @app.post("/chat")
-async def chat(req: ChatRequest):
-    """Proxy a chat request to the OpenRouter API."""
+async def chat(req: ChatRequest, db: Session = Depends(get_db)):
+    """Proxy a chat request to the OpenRouter API while persisting history."""
+    user = db.query(models.User).filter(models.User.id == req.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    user_msg = models.Message(user_id=user.id, role="user", content=req.message)
+    db.add(user_msg)
+    db.commit()
+
     response_text = await chat_with_openrouter(req.message)
+
+    bot_msg = models.Message(user_id=user.id, role="bot", content=response_text)
+    db.add(bot_msg)
+    db.commit()
+
     return {"response": response_text}
+
+
+@app.post("/users")
+def create_user(req: UserCreate, db: Session = Depends(get_db)):
+    """Create a new user profile or return existing by name."""
+    user = db.query(models.User).filter(models.User.name == req.name).first()
+    if user:
+        return {"id": user.id, "name": user.name, "preferences": user.preferences}
+    user = models.User(name=req.name, preferences=req.preferences)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return {"id": user.id, "name": user.name, "preferences": user.preferences}
+
+
+@app.put("/users/{user_id}/preferences")
+def update_preferences(user_id: int, req: PreferencesUpdate, db: Session = Depends(get_db)):
+    """Update stored preferences for a user."""
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.preferences = req.preferences
+    db.commit()
+    db.refresh(user)
+    return {"id": user.id, "name": user.name, "preferences": user.preferences}
+
+
+@app.get("/users/{user_id}/history")
+def get_history(user_id: int, db: Session = Depends(get_db)):
+    """Return chat history for a user."""
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    messages = (
+        db.query(models.Message)
+        .filter(models.Message.user_id == user_id)
+        .order_by(models.Message.timestamp)
+        .all()
+    )
+    history: List[dict] = [
+        {"role": m.role, "content": m.content, "timestamp": m.timestamp.isoformat()}
+        for m in messages
+    ]
+    return {"history": history}

--- a/backend/services/database.py
+++ b/backend/services/database.py
@@ -1,0 +1,12 @@
+"""Database setup for the application."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///./local.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/services/models.py
+++ b/backend/services/models.py
@@ -1,0 +1,29 @@
+"""SQLAlchemy models for user profiles and chat history."""
+
+from datetime import datetime
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    preferences = Column(Text, default="")
+
+    messages = relationship("Message", back_populates="user")
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    role = Column(String, index=True)
+    content = Column(Text)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="messages")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,10 @@
 </head>
 <body>
   <h1>AI Learning Lab</h1>
+  <div>
+    <input id="userId" type="text" placeholder="User ID" size="10" />
+    <button onclick="loadHistory()">Load History</button>
+  </div>
   <div id="chat"></div>
   <input id="prompt" type="text" placeholder="Say something..." size="40" />
   <button onclick="sendMessage()">Send</button>
@@ -20,6 +24,7 @@
   <script>
     const chatDiv = document.getElementById('chat');
     const promptInput = document.getElementById('prompt');
+    const userIdInput = document.getElementById('userId');
     const synth = window.speechSynthesis;
 
     async function sendMessage(text) {
@@ -31,11 +36,20 @@
       const response = await fetch('/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message })
+        body: JSON.stringify({ user_id: userIdInput.value, message })
       });
       const data = await response.json();
       appendMessage('bot', data.response);
       speak(data.response);
+    }
+
+    async function loadHistory() {
+      chatDiv.innerHTML = '';
+      const userId = userIdInput.value;
+      if (!userId) return;
+      const res = await fetch(`/users/${userId}/history`);
+      const data = await res.json();
+      data.history.forEach(msg => appendMessage(msg.role, msg.content));
     }
 
     function appendMessage(sender, text) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 httpx
+sqlalchemy


### PR DESCRIPTION
## Summary
- add SQLAlchemy-based SQLite database for user profiles and chat messages
- expose user management endpoints for preferences and history
- track user ID in frontend requests and allow history loading

## Testing
- `python -m py_compile backend/app/main.py backend/services/database.py backend/services/models.py backend/services/openrouter.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898892b03d88321830461e2c13abbf9