### PR TITLE
feat: allow OpenRouter key via .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ pip install -r requirements.txt
 
 2. **Configure environment**
 
-Set your OpenRouter API key so the backend can access language models:
+Set your OpenRouter API key so the backend can access language models. You can
+export it directly:
 
 ```bash
 export OPENROUTER_API_KEY="your_key_here"
+```
+
+Or create a `.env` file in the project root with the following content:
+
+```bash
+OPENROUTER_API_KEY=your_key_here
 ```
 
 3. **Run the web server**

--- a/backend/services/openrouter.py
+++ b/backend/services/openrouter.py
@@ -4,8 +4,10 @@ import os
 from typing import Any, Dict, List
 
 import httpx
+from dotenv import load_dotenv
 
 
+load_dotenv()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 httpx
 sqlalchemy
+python-dotenv


### PR DESCRIPTION
## Summary
- load .env file so OpenRouter key can be provided without exporting a shell variable
- document new .env option and add python-dotenv dependency

## Testing
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689bbb6b78348321ab8fcd6234252bd8