### PR TITLE
Serve frontend via FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OPENROUTER_API_KEY=your_key_here
 uvicorn backend.app.main:app --reload
 ```
 
-Visit `http://localhost:8000` and open `frontend/index.html` in a browser to interact with the chat interface.
+Visit `http://localhost:8000/` to access the frontend served by the backend. The page can call the API endpoints directly without any cross-origin configuration.
 
 ### Optional: HTTPS for Voice Streaming
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from backend.services.openrouter import (
@@ -153,3 +155,8 @@ def get_history(user_id: int, db: Session = Depends(get_db)):
         for m in messages
     ]
     return {"history": history}
+
+
+# Serve the frontend directory as static files at the root.
+frontend_dir = Path(__file__).resolve().parent.parent.parent / "frontend"
+app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -79,9 +79,10 @@
 
     let systemPrompt = '';
     let userId = null;
+    const API_BASE = '';
 
     async function loadProfiles() {
-      const res = await fetch('/profiles');
+      const res = await fetch(`${API_BASE}/profiles`);
       const profiles = await res.json();
       profiles.forEach((p) => {
         const btn = document.createElement('button');
@@ -111,7 +112,7 @@
       appendMessage('user', message);
       promptInput.value = '';
 
-      const response = await fetch('/chat/stream', {
+      const response = await fetch(`${API_BASE}/chat/stream`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -140,7 +141,7 @@
       chatDiv.innerHTML = '';
       const userId = userIdField.value;
       if (!userId) return;
-      const res = await fetch(`/users/${userId}/history`);
+      const res = await fetch(`${API_BASE}/users/${userId}/history`);
       const data = await res.json();
       data.history.forEach(msg => appendMessage(msg.role, msg.content));
     }


### PR DESCRIPTION
## Summary
- Serve frontend through FastAPI using StaticFiles
- Use same-origin API calls in index.html
- Document root frontend access in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4bde1c8988321bf23bd22a4417f1f