### PR TITLE
Create user via API when profile selected

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,13 +91,25 @@
       });
     }
 
-    function selectProfile(profile) {
-      landing.style.display = 'none';
-      chatInterface.style.display = 'block';
-      profileName.textContent = profile.name;
-      if (profile.avatar) profileAvatar.src = profile.avatar;
-      userIdField.value = profile.id;
-      loadHistory();
+    async function selectProfile(profile) {
+      try {
+        const res = await fetch('/users', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: profile.name })
+        });
+        if (!res.ok) throw new Error('User creation failed');
+        const data = await res.json();
+        userIdField.value = data.id;
+        landing.style.display = 'none';
+        chatInterface.style.display = 'block';
+        profileName.textContent = profile.name;
+        if (profile.avatar) profileAvatar.src = profile.avatar;
+        loadHistory();
+      } catch (err) {
+        console.error('Failed to create user', err);
+        alert('Could not create user profile. Please try again.');
+      }
 
     }
 


### PR DESCRIPTION
## Summary
- create user through `/users` endpoint when selecting a profile
- store returned user id for chat requests and show alert on failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4be0387a08321b049c1f8687f1af6