### PR TITLE
Handle missing chat history gracefully

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -140,9 +140,24 @@
       chatDiv.innerHTML = '';
       const userId = userIdField.value;
       if (!userId) return;
-      const res = await fetch(`/users/${userId}/history`);
-      const data = await res.json();
-      data.history.forEach(msg => appendMessage(msg.role, msg.content));
+      try {
+        const res = await fetch(`/users/${userId}/history`);
+        if (!res.ok) {
+          if (res.status === 404) {
+            console.warn(`No history found for user ${userId}`);
+            appendMessage('bot', 'No history yet. Start the conversation!');
+          } else {
+            console.error(`Failed to load history (status ${res.status})`);
+          }
+          return;
+        }
+        const data = await res.json();
+        if (Array.isArray(data.history)) {
+          data.history.forEach(msg => appendMessage(msg.role, msg.content));
+        }
+      } catch (err) {
+        console.error('Error loading history', err);
+      }
     }
 
     function appendMessage(sender, text) {


### PR DESCRIPTION
## Summary
- Avoid parsing JSON if `/users/{id}/history` returns non-OK
- Warn and show friendly message when history is missing

## Testing
- ⚠️ `pre-commit run --files frontend/index.html` *(pre-commit: command not found)*
- ✅ `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4be0353608321a4d5c25b170f9110