### PR TITLE
feat: add API key settings interface

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,13 @@
     <h1>Select Conversation</h1>
     <div style="margin-bottom:0.5rem">
       <button id="new-convo-btn">New</button>
+      <button id="settings-btn" title="Settings">⚙️</button>
+    </div>
+    <div id="settings-panel" style="display:none; margin-bottom:1rem">
+      <h2>API Keys</h2>
+      <div id="api-keys-list"></div>
+      <button id="add-key-btn">Add Key</button>
+      <button id="close-settings-btn">Close</button>
     </div>
     <div id="conversations"></div>
   </div>
@@ -123,6 +130,11 @@
     const profileAvatar = document.getElementById('profile-avatar');
     const userIdField = document.getElementById('user-id');
     const backBtn = document.getElementById('back-btn');
+    const settingsBtn = document.getElementById('settings-btn');
+    const settingsPanel = document.getElementById('settings-panel');
+    const apiKeysList = document.getElementById('api-keys-list');
+    const addKeyBtn = document.getElementById('add-key-btn');
+    const closeSettingsBtn = document.getElementById('close-settings-btn');
 
     const synth = window.speechSynthesis;
     let audioCtx; // for UI beeps
@@ -183,6 +195,48 @@
     let systemPrompt = '';
     let userId = null;
     const API_BASE = '';
+
+    async function loadApiKeys() {
+      try {
+        const res = await fetch(`${API_BASE}/settings/api_keys`);
+        const data = await res.json();
+        apiKeysList.innerHTML = '';
+        (data.keys || []).forEach((k) => {
+          const row = document.createElement('div');
+          row.className = 'api-key-row';
+          const name = document.createElement('span');
+          name.textContent = k.name;
+          const value = document.createElement('span');
+          value.textContent = k.value;
+          const editBtn = document.createElement('button');
+          editBtn.textContent = 'Edit';
+          editBtn.onclick = async () => {
+            const nv = prompt('Value for ' + k.name, k.value);
+            if (nv === null) return;
+            await fetch(`${API_BASE}/settings/api_keys`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name: k.name, value: nv })
+            });
+            loadApiKeys();
+          };
+          const delBtn = document.createElement('button');
+          delBtn.textContent = 'Delete';
+          delBtn.onclick = async () => {
+            if (!confirm('Delete ' + k.name + '?')) return;
+            await fetch(`${API_BASE}/settings/api_keys/` + encodeURIComponent(k.name), { method: 'DELETE' });
+            loadApiKeys();
+          };
+          row.appendChild(name);
+          row.appendChild(value);
+          row.appendChild(editBtn);
+          row.appendChild(delBtn);
+          apiKeysList.appendChild(row);
+        });
+      } catch (e) {
+        console.error('loadApiKeys', e);
+      }
+    }
 
     async function loadConversations() {
       try {
@@ -1108,6 +1162,26 @@
         importFile.value = '';
       };
     }
+
+    if (settingsBtn) settingsBtn.onclick = () => {
+      settingsPanel.style.display = 'block';
+      loadApiKeys();
+    };
+    if (closeSettingsBtn) closeSettingsBtn.onclick = () => {
+      settingsPanel.style.display = 'none';
+    };
+    if (addKeyBtn) addKeyBtn.onclick = async () => {
+      const name = prompt('API key name?');
+      if (!name) return;
+      const value = prompt('Value for ' + name + '?');
+      if (value === null) return;
+      await fetch(`${API_BASE}/settings/api_keys`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, value })
+      });
+      loadApiKeys();
+    };
 
     const newConvoBtn = document.getElementById('new-convo-btn');
     if (newConvoBtn) newConvoBtn.onclick = async () => {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -307,3 +307,47 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+#settings-btn {
+  margin-left: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  background: #444;
+  color: #e0e0e0;
+  border: 1px solid #666;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#settings-btn:hover {
+  background: #555;
+}
+
+#settings-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #2a2a2a;
+  border: 1px solid #666;
+  padding: 1rem;
+  display: none;
+  z-index: 1000;
+  min-width: 300px;
+  color: #e0e0e0;
+}
+
+#settings-panel h2 {
+  margin-top: 0;
+}
+
+#settings-panel .api-key-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+#settings-panel .api-key-row span {
+  flex: 1;
+  word-break: break-all;
+}

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from backend.app import main
+
+
+def test_api_key_crud(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_text("")
+    monkeypatch.setattr(main, "ENV_PATH", env_path)
+
+    client = TestClient(main.app)
+
+    resp = client.get("/settings/api_keys")
+    assert resp.status_code == 200
+    assert resp.json() == {"keys": []}
+
+    resp = client.post("/settings/api_keys", json={"name": "TEST_KEY", "value": "123"})
+    assert resp.status_code == 200
+
+    resp = client.get("/settings/api_keys")
+    assert resp.json() == {"keys": [{"name": "TEST_KEY", "value": "123"}]}
+
+    resp = client.post("/settings/api_keys", json={"name": "TEST_KEY", "value": "456"})
+    assert resp.status_code == 200
+    resp = client.get("/settings/api_keys")
+    assert resp.json() == {"keys": [{"name": "TEST_KEY", "value": "456"}]}
+
+    resp = client.delete("/settings/api_keys/TEST_KEY")
+    assert resp.status_code == 200
+    resp = client.get("/settings/api_keys")
+    assert resp.json() == {"keys": []}


### PR DESCRIPTION
## Summary
- add backend endpoints to manage API keys via .env
- add settings panel on landing page for API key CRUD
- style settings UI and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b14e9ed0208321aff20f15de36e7e3