### PR TITLE
Add comprehensive service and FastAPI route tests with mocks

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,20 @@
 # Testing Strategy
 
+## Dependencies
+
+Install the base and test packages before running the suite:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+Runtime dependencies such as `fastapi`, `sqlalchemy`, `httpx`,
+`python-dotenv`, `jinja2`, `elevenlabs`, `python-multipart`, `piper-tts`,
+`pedalboard`, `numpy`, `soundfile`, and `huggingface_hub` come from
+`requirements.txt`, while `pytest` and `pytest-asyncio` are provided by
+`requirements-dev.txt`.
+
 ## 1. Baseline tooling
 - **Testing framework**: `pytest` for Python with `pytest-asyncio` for async endpoints and services.
 - **Mocking HTTP calls**: use `respx` or `responses` to simulate external APIs like `openrouter`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/tests/routes/test_characters.py
+++ b/tests/routes/test_characters.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app import main
+from backend.services import models
+
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    models.Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    main.app.dependency_overrides[main.get_db] = override_get_db
+    with TestClient(main.app) as c:
+        yield c
+    main.app.dependency_overrides.clear()
+
+
+def test_character_crud_and_prompt(client, monkeypatch):
+    # Create
+    resp = client.post(
+        "/characters",
+        json={"name": "Hero", "system_prompt": "", "voice_id": "", "avatar": ""},
+    )
+    assert resp.status_code == 200
+    char_id = resp.json()["id"]
+
+    # List
+    resp = client.get("/characters")
+    assert resp.json()["characters"][0]["name"] == "Hero"
+
+    # Update
+    resp = client.put(f"/characters/{char_id}", json={"system_prompt": "Be nice"})
+    assert resp.json()["system_prompt"] == "Be nice"
+
+    # Suggest system prompt
+    async def fake_prompt(*args, **kwargs):
+        return "You are a kind assistant."
+
+    monkeypatch.setattr(main, "chat_with_openrouter", fake_prompt)
+    resp = client.post(
+        "/characters/suggest_system_prompt",
+        json={"genres": ["fantasy"], "traits": ["brave"]},
+    )
+    assert resp.status_code == 200
+    assert "prompt" in resp.json()
+
+    # Delete
+    resp = client.delete(f"/characters/{char_id}")
+    assert resp.json() == {"deleted": True}
+    assert client.get("/characters").json()["characters"] == []

--- a/tests/routes/test_speech_tts.py
+++ b/tests/routes/test_speech_tts.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app import main
+from backend.services import models
+
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    models.Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    main.app.dependency_overrides[main.get_db] = override_get_db
+    with TestClient(main.app) as c:
+        yield c
+    main.app.dependency_overrides.clear()
+
+
+def test_transcribe_success(client, monkeypatch):
+    # Mock secret lookup and httpx client
+    monkeypatch.setattr(main, "get_db_secret", lambda db, name: "KEY")
+
+    class DummyResp:
+        status_code = 200
+
+        def json(self):
+            return {"text": "hi"}
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, *args, **kwargs):
+            return DummyResp()
+
+    monkeypatch.setattr(main, "httpx", type("httpx", (), {"AsyncClient": DummyAsyncClient}))
+
+    files = {"file": ("a.wav", b"data", "audio/wav")}
+    resp = client.post("/speech/transcribe", files=files)
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "hi"}
+
+
+def test_tts_and_voices_without_key(client):
+    resp = client.post("/tts", json={"text": "hello", "voice_id": "v"})
+    assert resp.status_code == 503
+    resp = client.get("/tts/voices")
+    assert resp.status_code == 503

--- a/tests/routes/test_users_profiles_chat.py
+++ b/tests/routes/test_users_profiles_chat.py
@@ -1,0 +1,126 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app import main
+from backend.services import models
+
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    models.Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    main.app.dependency_overrides[main.get_db] = override_get_db
+    with TestClient(main.app) as c:
+        yield c
+    main.app.dependency_overrides.clear()
+
+
+def test_profiles_route(client):
+    resp = client.get("/profiles")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data[0]["name"] == "Alice"
+
+
+def test_user_crud_and_chat(client, monkeypatch):
+    # Create user
+    resp = client.post("/users", json={"name": "Tester"})
+    assert resp.status_code == 200
+    user_id = resp.json()["id"]
+
+    # List users
+    resp = client.get("/users")
+    assert resp.json()["users"][0]["name"] == "Tester"
+
+    # Update preferences
+    resp = client.put(f"/users/{user_id}/preferences", json={"preferences": "{\"lang\": \"en\"}"})
+    assert resp.status_code == 200
+    prefs = json.loads(resp.json()["preferences"])
+    assert prefs["lang"] == "en"
+
+    # Update avatar
+    resp = client.put(f"/users/{user_id}/avatar", json={"avatar": "url"})
+    assert resp.status_code == 200
+    prefs = json.loads(resp.json()["preferences"])
+    assert prefs["avatar"] == "url"
+
+    # Update meta
+    resp = client.put(
+        f"/users/{user_id}/meta", json={"system_prompt": "hi", "voice_id": "v1"}
+    )
+    assert resp.status_code == 200
+    prefs = json.loads(resp.json()["preferences"])
+    assert prefs["system_prompt"] == "hi"
+    assert prefs["voice_id"] == "v1"
+
+    # Rename
+    resp = client.put(f"/users/{user_id}/name", params={"name": "Renamed"})
+    assert resp.json()["name"] == "Renamed"
+
+    # Suggest conversation name with seed
+    resp = client.get("/conversations/suggest_name", params={"seed": 123})
+    assert "name" in resp.json()
+
+    # Chat endpoint stores history
+    async def fake_chat_with_openrouter(*args, **kwargs):
+        return "bot reply"
+
+    monkeypatch.setattr(main, "chat_with_openrouter", fake_chat_with_openrouter)
+    resp = client.post(
+        "/chat", json={"user_id": user_id, "message": "hello", "system_prompt": "s"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "bot reply"}
+
+    # History should contain user and bot messages
+    history = client.get(f"/users/{user_id}/history").json()["history"]
+    roles = [h["role"] for h in history]
+    assert roles == ["user", "bot"]
+
+    # Import additional history
+    resp = client.post(
+        f"/users/{user_id}/history/import",
+        json={"messages": [{"role": "user", "content": "imported"}]},
+    )
+    assert resp.json() == {"imported": 1}
+
+    history = client.get(f"/users/{user_id}/history").json()["history"]
+    contents = [h["content"] for h in history]
+    assert "imported" in contents
+
+    # Suggest name from history (mocked)
+    async def fake_title(*args, **kwargs):
+        return "Amazing Chat Title For Tester"
+
+    monkeypatch.setattr(main, "chat_with_openrouter", fake_title)
+    resp = client.post(f"/users/{user_id}/suggest_name")
+    assert resp.status_code == 200
+    assert "name" in resp.json()
+
+    # Delete user
+    resp = client.delete(f"/users/{user_id}")
+    assert resp.json() == {"deleted": True}
+    assert client.get("/users").json()["users"] == []

--- a/tests/services/test_openrouter.py
+++ b/tests/services/test_openrouter.py
@@ -1,0 +1,94 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+import pytest
+
+from backend.services import openrouter
+
+
+class DummySession:
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def dummy_session(monkeypatch):
+    monkeypatch.setattr(openrouter, "SessionLocal", lambda: DummySession())
+
+
+class DummyResponse:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"choices": [{"message": {"content": "Hello"}}]}
+
+
+class DummyStream:
+    lines = [
+        'data: {"choices":[{"delta":{"content":"He"}}]}',
+        'data: {"choices":[{"delta":{"content":"llo"}}]}',
+        'data: [DONE]',
+    ]
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_lines(self):
+        for line in self.lines:
+            yield line
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json, headers):
+        return DummyResponse()
+
+    def stream(self, method, url, json, headers):
+        return DummyStream()
+
+
+@pytest.mark.asyncio
+async def test_chat_with_openrouter_no_key(monkeypatch):
+    monkeypatch.setattr(openrouter, "get_db_secret", lambda db, name: None)
+    result = await openrouter.chat_with_openrouter(message="hi")
+    assert result == "OpenRouter API key is not configured."
+
+
+@pytest.mark.asyncio
+async def test_chat_with_openrouter_success(monkeypatch):
+    monkeypatch.setattr(openrouter, "get_db_secret", lambda db, name: "key")
+    monkeypatch.setattr(openrouter.httpx, "AsyncClient", DummyClient)
+    result = await openrouter.chat_with_openrouter(message="hi")
+    assert result == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_with_openrouter_no_key(monkeypatch):
+    monkeypatch.setattr(openrouter, "get_db_secret", lambda db, name: None)
+    tokens = [t async for t in openrouter.stream_chat_with_openrouter(message="hi")]
+    assert tokens == ["OpenRouter API key is not configured."]
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_with_openrouter_success(monkeypatch):
+    monkeypatch.setattr(openrouter, "get_db_secret", lambda db, name: "key")
+    monkeypatch.setattr(openrouter.httpx, "AsyncClient", DummyClient)
+    tokens = []
+    async for tok in openrouter.stream_chat_with_openrouter(message="hi"):
+        tokens.append(tok)
+    assert "".join(tokens) == "Hello"

--- a/tests/services/test_secrets.py
+++ b/tests/services/test_secrets.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.services import models, secrets
+
+
+@pytest.fixture(autouse=True)
+def fixed_master_key(monkeypatch):
+    monkeypatch.setattr(secrets, "_MASTER_KEY", b"A" * 32)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    models.Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_encrypt_decrypt_roundtrip():
+    token = secrets.encrypt("secret")
+    assert token != "secret"
+    assert secrets.decrypt(token) == "secret"
+
+
+def test_set_get_delete_secret(db_session):
+    secrets.set_secret(db_session, "API", "123")
+    assert secrets.get_secret(db_session, "API") == "123"
+
+    secrets.set_secret(db_session, "API", "456")
+    assert secrets.get_secret(db_session, "API") == "456"
+
+    secrets.delete_secret(db_session, "API")
+    assert secrets.get_secret(db_session, "API") is None
+
+
+def test_get_secret_env_fallback(monkeypatch, db_session):
+    monkeypatch.setenv("ALLOW_ENV_SECRETS", "1")
+    monkeypatch.setenv("ENV_ONLY", "VALUE")
+    assert secrets.get_secret(db_session, "ENV_ONLY") == "VALUE"

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -15,6 +15,9 @@ Base.metadata.create_all(bind=engine)
 
 def test_chat_stream_persists_bot_message(monkeypatch):
     db = SessionLocal()
+    # Ensure a clean state for the test database
+    db.query(models.User).filter(models.User.name == "StreamTester").delete()
+    db.commit()
     user = models.User(name="StreamTester")
     db.add(user)
     db.commit()


### PR DESCRIPTION
## Summary
- Add dedicated `tests/routes` covering profiles, user CRUD, chat, history import, and conversation naming
- Include character management and system prompt suggestion tests
- Add speech transcription and TTS fallback tests
- Document test dependencies and provide `requirements-dev.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b437b7bc0483219badef36ebb58007