### PR TITLE
feat: hide chat controls behind hamburger menu on mobile

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,7 @@
         <p class="tagline">Resume a conversation or start a new one.</p>
         <div class="hero-actions">
           <button id="new-convo-btn" class="primary">Start New</button>
-          <button id="settings-btn" title="Settings">⚙️ Settings</button>
+          <button id="settings-btn" class="settings-btn" title="Settings">⚙️ Settings</button>
           <a id="avatar-gallery-link" class="secondary" href="avatar-gallery" title="Browse and download generated avatars">Avatar Gallery</a>
           <a id="image-generate-link" class="secondary" href="image_generate" title="Generate images in a chat-style view">Image Generate</a>
         </div>
@@ -52,6 +52,7 @@
     <input type="hidden" id="user-id" />
     <div id="topbar">
       <button id="back-btn" title="Back to conversations">⟵ Back</button>
+      <button id="menu-btn" title="Menu">☰</button>
       <img id="profile-avatar" src="" alt="avatar" />
       <span id="profile-name"></span>
       <span class="title">AI Learning Lab</span>
@@ -59,6 +60,7 @@
     <div id="container">
       <div id="sidebar">
         <h3>Configuration</h3>
+        <button class="settings-btn">Settings</button>
         <label for="persona-select">Character:</label>
         <select id="persona-select">
           <option value="">(loading…)</option>
@@ -136,7 +138,7 @@
             <option value="on" selected>Speak: On</option>
             <option value="off">Speak: Off</option>
           </select>
-          <span class="export-controls">
+          <span class="export-controls" id="export-controls">
             <select id="export-format" title="Export conversation as">
               <option value="markdown" selected>Export: Markdown</option>
               <option value="json">Export: JSON</option>
@@ -517,8 +519,12 @@
     const profileAvatar = document.getElementById('profile-avatar');
     const userIdField = document.getElementById('user-id');
     const backBtn = document.getElementById('back-btn');
-    const settingsBtn = document.getElementById('settings-btn');
+    const menuBtn = document.getElementById('menu-btn');
+    const sidebar = document.getElementById('sidebar');
     const settingsPanel = document.getElementById('settings-panel');
+    const settingsBtns = document.querySelectorAll('.settings-btn');
+    const exportControls = document.getElementById('export-controls');
+    const inputArea = document.getElementById('input-area');
     const apiKeysList = document.getElementById('api-keys-list');
     const addKeyBtn = document.getElementById('add-key-btn');
     const closeSettingsBtn = document.getElementById('close-settings-btn');
@@ -1710,11 +1716,13 @@
       });
     }
 
-    if (settingsBtn) settingsBtn.onclick = () => {
-      settingsPanel.style.display = 'block';
-      loadApiKeys();
-      initImageSettings();
-    };
+    settingsBtns.forEach(btn => {
+      btn.onclick = () => {
+        settingsPanel.style.display = 'block';
+        loadApiKeys();
+        initImageSettings();
+      };
+    });
     if (closeSettingsBtn) closeSettingsBtn.onclick = () => {
       settingsPanel.style.display = 'none';
     };
@@ -1731,6 +1739,22 @@
       loadApiKeys();
     };
 
+    if (menuBtn) menuBtn.onclick = () => {
+      if (sidebar) sidebar.classList.toggle('open');
+    };
+
+    function relocateExportControls() {
+      if (!exportControls || !sidebar || !inputArea) return;
+      if (window.innerWidth <= 780) {
+        if (!sidebar.contains(exportControls)) sidebar.appendChild(exportControls);
+      } else {
+        if (!inputArea.contains(exportControls)) inputArea.appendChild(exportControls);
+        sidebar.classList.remove('open');
+      }
+    }
+    window.addEventListener('resize', relocateExportControls);
+    relocateExportControls();
+
     const newConvoBtn = document.getElementById('new-convo-btn');
     console.log('loaded button');
     console.log(newConvoBtn);
@@ -1742,7 +1766,7 @@
 
     // Open settings automatically if URL hash requests it
     if (window.location.hash && window.location.hash.toLowerCase().includes('settings')) {
-      try { settingsBtn && settingsBtn.click(); } catch (e) {}
+      try { settingsBtns[0] && settingsBtns[0].click(); } catch (e) {}
     }
     
     // Back to conversations

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -108,6 +108,19 @@ body {
 
 #back-btn:hover { background: #555; }
 
+#menu-btn {
+  display: none;
+  margin-right: 0.75rem;
+  padding: 0.3rem 0.6rem;
+  background: #444;
+  color: #e0e0e0;
+  border: 1px solid #666;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#menu-btn:hover { background: #555; }
+
 #topbar img {
   width: 40px;
   height: 40px;
@@ -559,13 +572,27 @@ body {
     min-height: calc(100dvh - 70px);
   }
   #sidebar {
-    width: 100%;
-    max-height: 40vh;
-    margin-bottom: 0.5rem;
-    border-right: none;
-    border-bottom: 1px solid #666;
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 80%;
+    height: 100%;
+    max-height: none;
+    margin: 0;
+    border-right: 1px solid #666;
+    border-bottom: none;
+    z-index: 1000;
+    background: #2a2a2a;
+    overflow-y: auto;
+    padding: 1rem;
   }
-  #chat-area { min-height: 60vh; }
+  #sidebar.open {
+    display: block;
+  }
+  #chat-area {
+    min-height: calc(100dvh - 70px);
+  }
   #input-area {
     flex-wrap: wrap;
     align-items: stretch;
@@ -575,16 +602,21 @@ body {
     min-height: 3.2rem;
     max-height: 30vh;
   }
-  .export-controls {
-    width: 100%;
+  #input-area .export-controls {
+    display: none;
+  }
+  #sidebar .export-controls {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 0.4rem;
-    margin-left: 0;
+    margin: 0 0 1rem 0;
   }
   #sidebar button,
   #input-area button {
     min-height: 40px; /* better tap targets */
+  }
+  #menu-btn {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Summary
- add hamburger menu for chat interface on mobile
- relocate character configuration and export controls into collapsible sidebar
- ensure settings buttons work from new menu

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `python tools/run_tests_timeout.py --timeout 40 tests -- --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68b5b4108f0c8321b1e34a756a1b1115