### PR TITLE
Improve mobile chat input layout and speech toggle UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -130,30 +130,36 @@
         <div id="chat-avatar-bg" aria-hidden="true"></div>
         <div id="chat"></div>
         <div id="input-area">
-          <textarea id="prompt" placeholder="Say something... (Shift+Enter for newline)" rows="3"></textarea>
-          <button id="send-btn">Send</button>
-          <button id="listen-btn" title="Push-to-talk (Shift+S)">🎤</button>
-          <span id="recording-hint" aria-live="polite">Recording…</span>
-          <select id="speech-toggle" title="Speech synthesis for replies">
-            <option value="on" selected>Speak: ElevenLabs</option>
-            <option value="piper-fx">Speak: Piper (FX)</option>
-            <option value="piper-raw">Speak: Piper (Raw)</option>
-            <option value="off">Speak: Off</option>
-          </select>
-          <span id="piper-controls" title="Piper voice" style="display:none; gap:0.25rem; align-items:center;">
-            <select id="piper-voice" style="max-width:16rem"></select>
-            <button id="piper-voice-reload" class="icon-btn" type="button" title="Reload local Piper voices">⟳</button>
-          </span>
-          <span class="export-controls" id="export-controls">
-            <select id="export-format" title="Export conversation as">
-              <option value="markdown" selected>Export: Markdown</option>
-              <option value="json">Export: JSON</option>
-              <option value="text">Export: Text</option>
-            </select>
-            <button id="export-btn" title="Download conversation">Export</button>
-            <button id="import-btn" title="Import conversation JSON">Import</button>
-            <input id="import-file" type="file" accept="application/json" style="display:none" />
-          </span>
+          <div class="input-main-row">
+            <textarea id="prompt" placeholder="Say something... (Shift+Enter for newline)" rows="3"></textarea>
+            <button id="send-btn">Send</button>
+          </div>
+          <div class="input-controls">
+            <button id="listen-btn" title="Push-to-talk (Shift+S)">🎤</button>
+            <span id="recording-hint" aria-live="polite">Recording…</span>
+            <div id="speech-controls" title="Speech synthesis for replies">
+              <button id="speech-toggle" type="button" class="icon-btn" aria-pressed="true" aria-label="Speech synthesis on">🗣️</button>
+              <select id="speech-mode" title="Choose speech engine">
+                <option value="on" selected>ElevenLabs</option>
+                <option value="piper-fx">Piper (FX)</option>
+                <option value="piper-raw">Piper (Raw)</option>
+              </select>
+            </div>
+            <span id="piper-controls" title="Piper voice" style="display:none; gap:0.25rem; align-items:center;">
+              <select id="piper-voice" style="max-width:16rem"></select>
+              <button id="piper-voice-reload" class="icon-btn" type="button" title="Reload local Piper voices">⟳</button>
+            </span>
+            <span class="export-controls" id="export-controls">
+              <select id="export-format" title="Export conversation as">
+                <option value="markdown" selected>Export: Markdown</option>
+                <option value="json">Export: JSON</option>
+                <option value="text">Export: Text</option>
+              </select>
+              <button id="export-btn" title="Download conversation">Export</button>
+              <button id="import-btn" title="Import conversation JSON">Import</button>
+              <input id="import-file" type="file" accept="application/json" style="display:none" />
+            </span>
+          </div>
         </div>
         <!-- voice-config removed: voice now configured per character in the editor -->
       </div>
@@ -532,6 +538,8 @@
     const settingsBtns = document.querySelectorAll('.settings-btn');
     const exportControls = document.getElementById('export-controls');
     const inputArea = document.getElementById('input-area');
+    const speechToggleBtn = document.getElementById('speech-toggle');
+    const speechModeSelect = document.getElementById('speech-mode');
     const apiKeysList = document.getElementById('api-keys-list');
     const addKeyBtn = document.getElementById('add-key-btn');
     const closeSettingsBtn = document.getElementById('close-settings-btn');
@@ -541,6 +549,49 @@
     // Track current ElevenLabs audio playback so we can cancel it
     let currentTtsAudio = null;
     let currentTtsUrl = null;
+
+    function isSpeechEnabled() {
+      if (!speechToggleBtn) return true;
+      return (speechToggleBtn.dataset.state || 'on') !== 'off';
+    }
+
+    function setSpeechEnabled(enabled) {
+      if (!speechToggleBtn) return;
+      speechToggleBtn.dataset.state = enabled ? 'on' : 'off';
+      speechToggleBtn.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+      speechToggleBtn.classList.toggle('speech-off', !enabled);
+      updateSpeechModeVisibility();
+    }
+
+    function getSpeechMode() {
+      if (!speechModeSelect) return 'on';
+      return speechModeSelect.value || 'on';
+    }
+
+    function getSpeechModeLabel() {
+      if (!speechModeSelect) return 'ElevenLabs';
+      const opt = speechModeSelect.options[speechModeSelect.selectedIndex];
+      return opt ? opt.textContent : (speechModeSelect.value || 'ElevenLabs');
+    }
+
+    function updateSpeechModeVisibility() {
+      const pc = document.getElementById('piper-controls');
+      if (pc) {
+        const mode = getSpeechMode();
+        const showPiper = isSpeechEnabled() && (mode === 'piper-fx' || mode === 'piper-raw');
+        pc.style.display = showPiper ? 'inline-flex' : 'none';
+      }
+      updateSpeechToggleButtonUI();
+    }
+
+    function updateSpeechToggleButtonUI() {
+      if (!speechToggleBtn) return;
+      const enabled = isSpeechEnabled();
+      speechToggleBtn.textContent = enabled ? '🗣️' : '❌';
+      const label = enabled ? `Speech synthesis on (${getSpeechModeLabel()})` : 'Speech synthesis off';
+      speechToggleBtn.setAttribute('aria-label', label);
+      speechToggleBtn.title = label;
+    }
     // Stop all ongoing speech/audio helpers
     function stopAllSpeech() {
       try { synth.cancel(); } catch (e) {}
@@ -1317,9 +1368,7 @@
         chatDiv.scrollTop = chatDiv.scrollHeight;
       }
       // Speak only if enabled
-      const speechToggle = document.getElementById('speech-toggle');
-      const wantSpeech = !speechToggle || speechToggle.value !== 'off';
-      if (wantSpeech) {
+      if (isSpeechEnabled()) {
         speak(botText);
       }
     }
@@ -1364,14 +1413,10 @@
     }
 
     async function speak(text) {
-      // Respect toggle immediately
-      const st = document.getElementById('speech-toggle');
-      if (st && st.value === 'off') return;
+      if (!isSpeechEnabled()) return;
 
-      // Strip gesture-like *text* which does not read well in TTS
       const safeText = sanitizeForTTS(text);
 
-      // Stop any ongoing speech first to avoid overlap
       try { synth.cancel(); } catch (e) {}
       try {
         if (currentTtsAudio) {
@@ -1385,16 +1430,9 @@
       currentTtsAudio = null;
       currentTtsUrl = null;
 
-      // Choose engine from toggle: ElevenLabs (default), Piper (FX/Raw), or Off
       try {
-        const mode = st ? st.value : 'on';
-        // Piper engines
+        const mode = getSpeechMode();
         if (mode === 'piper-fx' || mode === 'piper-raw') {
-          // Choose a Piper voice:
-          // 1) window.PIPER_VOICE_ID if set
-          // 2) If ELEVENLABS_VOICE_ID looks like a Piper id (contains en_GB-..., ends with .onnx), use it
-          // 3) Query local Piper voices; pick first
-          // 4) Fallback to a common default id
           let voiceId = (window.PIPER_VOICE_ID || '').trim();
           const vField = (window.ELEVENLABS_VOICE_ID || '').trim();
           const looksLikePiper = /[a-z]{2}_[A-Z]{2}-/.test(vField) || /\.onnx$/i.test(vField);
@@ -1416,7 +1454,7 @@
           }
           if (!voiceId) voiceId = 'en_GB-alba-medium';
           if (!voiceId) throw new Error('No Piper voice configured');
-          if (st && st.value === 'off') return;
+          if (!isSpeechEnabled()) return;
           const qs = new URLSearchParams({ text: safeText, voice_id: voiceId, preset: 'wizard' });
           if (mode === 'piper-raw') qs.set('bypass_fx', 'true');
           const piperUrl = `${API_BASE}/tts/stream/piper?${qs.toString()}`;
@@ -1428,7 +1466,7 @@
             try { profileAvatar.classList.add('speaking'); } catch (e) {}
           }).catch((err) => {
             console.warn('[speak] Piper streaming play failed; falling back to SpeechSynthesis', err);
-            if (!st || st.value !== 'off') {
+            if (isSpeechEnabled()) {
               const u = new SpeechSynthesisUtterance(safeText);
               u.onstart = () => { try { profileAvatar.classList.add('speaking'); } catch (e) {} };
               u.onend = () => { try { profileAvatar.classList.remove('speaking'); } catch (e) {} };
@@ -1442,24 +1480,21 @@
           return;
         }
 
-        // ElevenLabs engine (default)
         const voiceId = (window.ELEVENLABS_VOICE_ID || '').trim();
         if (!voiceId) {
           console.info('[speak] Skipping ElevenLabs: no voice configured (set window.ELEVENLABS_VOICE_ID)');
         } else {
           console.info('[speak] Attempting ElevenLabs streaming via /tts/stream with voice:', voiceId);
-          // Check toggle again before playing
-          if (st && st.value === 'off') return;
+          if (!isSpeechEnabled()) return;
           const streamUrl = `${API_BASE}/tts/stream?voice_id=${encodeURIComponent(voiceId)}&text=${encodeURIComponent(safeText)}`;
           const audio = new Audio(streamUrl);
           currentTtsAudio = audio;
-          currentTtsUrl = null; // using URL directly, not object URL
+          currentTtsUrl = null;
           audio.play().then(() => {
             console.info('[speak] Playing ElevenLabs streaming audio');
             try { profileAvatar.classList.add('speaking'); } catch (e) {}
           }).catch(async (err) => {
             console.warn('[speak] Streaming play failed, trying buffered /tts', err);
-            // Buffered fallback
             try {
               const res = await fetch(`${API_BASE}/tts`, {
                 method: 'POST',
@@ -1470,7 +1505,7 @@
               if (res.ok && ct.includes('audio')) {
                 const blob = await res.blob();
                 if (blob.size > 0) {
-                  if (st && st.value === 'off') return;
+                  if (!isSpeechEnabled()) return;
                   const url = URL.createObjectURL(blob);
                   const a2 = new Audio(url);
                   currentTtsAudio = a2;
@@ -1480,7 +1515,7 @@
                     try { profileAvatar.classList.add('speaking'); } catch (e) {}
                   }).catch((err2) => {
                     console.warn('[speak] Buffered play blocked; will fallback to speechSynthesis', err2);
-                    if (!st || st.value !== 'off') {
+                    if (isSpeechEnabled()) {
                       const u = new SpeechSynthesisUtterance(safeText);
                       u.onstart = () => { try { profileAvatar.classList.add('speaking'); } catch (e) {} };
                       u.onend = () => { try { profileAvatar.classList.remove('speaking'); } catch (e) {} };
@@ -1501,7 +1536,6 @@
             }
             // Final fallback below
           });
-          // For streaming path, ensure we clear indicator when stream ends
           audio.onended = () => {
             currentTtsAudio = null;
             try { profileAvatar.classList.remove('speaking'); } catch (e) {}
@@ -1511,10 +1545,10 @@
       } catch (e) {
         console.error('[speak] ElevenLabs flow threw error; falling back to speechSynthesis', e);
       }
-      // Browser speech synthesis fallback
+
       const utterance = new SpeechSynthesisUtterance(text);
       console.info('[speak] Using browser SpeechSynthesis');
-      if (!st || st.value !== 'off') {
+      if (isSpeechEnabled()) {
         utterance.onstart = () => { try { profileAvatar.classList.add('speaking'); } catch (e) {} };
         utterance.onend = () => { try { profileAvatar.classList.remove('speaking'); } catch (e) {} };
         synth.speak(utterance);
@@ -1758,34 +1792,40 @@
       }
     });
 
-    // Set up speech toggle persistence and behavior
-    const speechToggleEl = document.getElementById('speech-toggle');
-    if (speechToggleEl) {
+    // Set up speech controls persistence and behavior
+    if (speechToggleBtn) {
+      let saved = 'on';
       try {
-        const saved = localStorage.getItem('speechToggle');
-        if (saved === 'on' || saved === 'off') speechToggleEl.value = saved;
+        const stored = localStorage.getItem('speechToggle');
+        if (stored === 'on' || stored === 'off') saved = stored;
       } catch (e) {}
-      speechToggleEl.addEventListener('change', () => {
-        try { localStorage.setItem('speechToggle', speechToggleEl.value); } catch (e) {}
-        if (speechToggleEl.value === 'off') {
-          try { synth.cancel(); } catch (e) {}
-          try {
-            if (currentTtsAudio) {
-              currentTtsAudio.pause();
-              currentTtsAudio.src = '';
-            }
-            if (currentTtsUrl) URL.revokeObjectURL(currentTtsUrl);
-          } catch (e) {}
-          currentTtsAudio = null;
-          currentTtsUrl = null;
+      setSpeechEnabled(saved !== 'off');
+      speechToggleBtn.addEventListener('click', () => {
+        const nextState = !isSpeechEnabled();
+        setSpeechEnabled(nextState);
+        try { localStorage.setItem('speechToggle', nextState ? 'on' : 'off'); } catch (e) {}
+        if (!nextState) {
+          stopAllSpeech();
         }
-        // Toggle Piper controls visibility
-        const pc = document.getElementById('piper-controls');
-        if (pc) pc.style.display = (speechToggleEl.value === 'piper-fx' || speechToggleEl.value === 'piper-raw') ? 'inline-flex' : 'none';
       });
-      // Initial show/hide based on restored value
-      const pc0 = document.getElementById('piper-controls');
-      if (pc0) pc0.style.display = (speechToggleEl.value === 'piper-fx' || speechToggleEl.value === 'piper-raw') ? 'inline-flex' : 'none';
+    } else {
+      setSpeechEnabled(true);
+    }
+
+    if (speechModeSelect) {
+      try {
+        const savedMode = localStorage.getItem('speechMode');
+        if (savedMode && Array.from(speechModeSelect.options).some((opt) => opt.value === savedMode)) {
+          speechModeSelect.value = savedMode;
+        }
+      } catch (e) {}
+      speechModeSelect.addEventListener('change', () => {
+        updateSpeechModeVisibility();
+        try { localStorage.setItem('speechMode', speechModeSelect.value); } catch (e) {}
+      });
+      updateSpeechModeVisibility();
+    } else {
+      updateSpeechModeVisibility();
     }
 
     // Restore persisted Piper voice id

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -241,16 +241,51 @@ body {
 
 #input-area {
   border-top: 1px solid #666;
-  padding: 0.5rem;
+  padding: 0.75rem;
   background: #2a2a2a;
   display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+#input-area .input-main-row {
+  display: flex;
   gap: 0.5rem;
-  align-items: flex-start;
+  align-items: stretch;
+  width: 100%;
+}
+
+#input-area .input-main-row #send-btn {
+  align-self: stretch;
+}
+
+#send-btn {
+  padding: 0.45rem 0.9rem;
+  background: #444;
+  color: #e0e0e0;
+  border: 1px solid #666;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+#send-btn:hover {
+  background: #555;
+  border-color: #777;
+}
+
+#input-area .input-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
 }
 
 #prompt {
   flex: 1;
-  min-height: 3.5rem;
+  min-height: 4rem;
   max-height: 40vh;
   padding: 0.5rem;
   background: #3a3a3a;
@@ -261,7 +296,7 @@ body {
 }
 
 #listen-btn {
-  margin-left: 0.5rem;
+  margin-left: 0;
   padding: 0.4rem 0.7rem;
   background: #444;
   color: #e0e0e0;
@@ -302,7 +337,7 @@ body {
 }
 
 #recording-hint {
-  margin-left: 0.5rem;
+  margin-left: 0;
   font-size: 0.9rem;
   color: #ff8a80;
   opacity: 0;
@@ -313,17 +348,62 @@ body {
   opacity: 1;
 }
 
+#speech-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 #speech-toggle {
-  margin-left: 0.5rem;
-  padding: 0.3rem 0.4rem;
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  background: #444;
+  color: #fff;
+  border: 1px solid #666;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+#speech-toggle:hover {
+  background: #555;
+}
+
+#speech-toggle:active {
+  transform: scale(0.95);
+}
+
+#speech-toggle.speech-off {
+  background: #7a1f1f;
+  border-color: #ff6b6b;
+}
+
+#speech-mode {
+  padding: 0.3rem 0.45rem;
   background: #3a3a3a;
   color: #e0e0e0;
   border: 1px solid #666;
   border-radius: 6px;
+  min-width: 8.5rem;
+  max-width: 100%;
+}
+
+#speech-mode option {
+  color: #000;
 }
 
 .export-controls {
-  margin-left: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+#export-controls {
+  margin-left: auto;
 }
 
 #export-format {
@@ -601,13 +681,23 @@ body {
     min-height: calc(100dvh - 70px);
   }
   #input-area {
-    flex-wrap: wrap;
-    align-items: stretch;
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+  #input-area .input-main-row {
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  #input-area .input-main-row #send-btn {
+    width: 100%;
   }
   #prompt {
     width: 100%;
-    min-height: 3.2rem;
-    max-height: 30vh;
+    min-height: 4.5rem;
+    max-height: 35vh;
+  }
+  #input-area .input-controls {
+    gap: 0.6rem;
   }
   #input-area .export-controls {
     display: none;


### PR DESCRIPTION
## Summary
- restyle the chat input area to give the textarea more space and stack controls cleanly on narrow screens
- replace the speech select box with an icon toggle plus engine picker and persist its state in local storage
- update speech playback logic to honour the new toggle helper APIs and hide Piper controls when speech is disabled

## Testing
- No automated tests (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce916237208321a03dab56264a3541